### PR TITLE
fix: permissões de escrita em wp-content/uploads (Elementor Google Fonts)

### DIFF
--- a/extras/init
+++ b/extras/init
@@ -18,8 +18,14 @@ echo "Fim da instalação do NewRelic"
 
 echo "Ajuste nas permissões da pasta uploads"
 rm -rf /var/www/html/wp-content
+chown -R www-data:www-data /var/www/html
 find /var/www/html -type d -exec chmod 755 {} \;
 find /var/www/html -type f -exec chmod 644 {} \;
+# wp-content/uploads precisa ser writable pelo PHP (Elementor gera Google Fonts CSS em runtime,
+# Contact Form 7 gera captchas/uploads, iThemes Security grava logs). Sem 775, o processo
+# PHP (www-data) não consegue criar sites/{N}/elementor/google-fonts/css/*.css e o WordPress
+# serve 404 HTML — navegador rejeita por MIME mismatch ('text/html' não é stylesheet).
+find /var/www/html -type d -path '*/wp-content/uploads*' -exec chmod 775 {} \;
 chmod 755 /var/www/html
 
 echo "Fim do script"


### PR DESCRIPTION
## Problema

O console do browser em páginas com Elementor retorna múltiplos erros:

```
Refused to apply style from 'https://www.adventistas.org/pt/mordomiacrista/wp-content/uploads/sites/16/elementor/google-fonts/css/bebasneue.css'
because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.
```

(ocorre para `bebasneue`, `barlow`, `robotoslab`, `roboto`, `montserrat`, `robotocondensed` — qualquer Google Font usada pelo Elementor).

## Causa raiz

O Elementor gera dinamicamente arquivos em `wp-content/uploads/sites/{BLOG_ID}/elementor/google-fonts/css/*.css` na primeira requisição de cada fonte.

No `extras/init` atual:
1. Falta `chown` para `www-data` — após o `COPY` do Dockerfile, o ownership pode não ser preservado no ECS.
2. `chmod 755` em diretórios só dá write ao **owner** — se o owner não for `www-data`, o PHP (rodando como www-data) não consegue criar os arquivos.

Quando o Elementor tenta criar o CSS e falha por permissão, o WordPress responde com 404 HTML. O browser recebe `Content-Type: text/html` num `<link rel="stylesheet">` e rejeita por **strict MIME checking**.

## Fix

- `chown -R www-data:www-data /var/www/html` antes dos chmods
- `chmod 775` em todos os diretórios sob `wp-content/uploads` (permite write por group `www-data`)

Affects todos os multisites (`/pt/`, `/es/`) e plugins que escrevem em uploads (Elementor, Contact Form 7, iThemes Security, AS3CF offload cache).

## Próximos passos (fora desse PR)

1. **Persistência via EFS** — `task-definition.json` tem `"volumes": []`. Cada novo container regenera o cache do zero. Recomenda-se montar EFS em `/var/www/html/{pt,es}/wp-content/uploads`.
2. **Regenerar no deploy** — no admin do Elementor: `Tools → Regenerate CSS & Data`.
3. **Auth keys hardcoded no repo** — `app/pt/wp-config.php` linhas 62-69 têm `AUTH_KEY`/`SECURE_AUTH_KEY`/`NONCE_SALT` em plaintext no repo público. Migrar para env vars e **rotacionar** urgentemente.

## Teste pós-deploy

Acessar `https://www.adventistas.org/pt/mordomiacrista/projeto/biblioteca-de-mordomia-crista/` → DevTools → Console deve ficar limpo de erros `Refused to apply style`.