### PR TITLE
feat: persistência EFS para wp-content/uploads (pt/es)

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -29,7 +29,18 @@
       "resourceRequirements": null,
       "ulimits": null,
       "dnsServers": null,
-      "mountPoints": [],
+      "mountPoints": [
+        {
+          "sourceVolume": "uploads-pt",
+          "containerPath": "/var/www/html/pt/wp-content/uploads",
+          "readOnly": false
+        },
+        {
+          "sourceVolume": "uploads-es",
+          "containerPath": "/var/www/html/es/wp-content/uploads",
+          "readOnly": false
+        }
+      ],
       "workingDirectory": null,
       "secrets": null,
       "dockerSecurityOptions": null,
@@ -104,5 +115,28 @@
   "cpu": null,
   "inferenceAccelerators": null,
   "proxyConfiguration": null,
-  "volumes": []
+  "volumes": [
+    {
+      "name": "uploads-pt",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "fs-REPLACE_ME",
+        "rootDirectory": "/pt-uploads",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "iam": "DISABLED"
+        }
+      }
+    },
+    {
+      "name": "uploads-es",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "fs-REPLACE_ME",
+        "rootDirectory": "/es-uploads",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": {
+          "iam": "DISABLED"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Contexto

O `task-definition.json` atual tem `"volumes": []` e `"mountPoints": []`. Cada novo container ECS sobe sem o cache de uploads do anterior, e todo arquivo gerado dinamicamente em runtime (Elementor Google Fonts, Contact Form 7 captchas, upload de mídia) é perdido ao próximo deploy/scaling event.

Isso amplifica o problema corrigido em #2: mesmo com permissões OK, o Elementor precisa regenerar todos os CSS de fontes a cada container novo. Se houver múltiplas tasks no service, uma pode ter o arquivo e outra não → respostas inconsistentes.

## Fix

Adiciona 2 volumes EFS (um para `/pt/`, outro para `/es/`) com mount point em `wp-content/uploads`.

```json
"volumes": [
  { "name": "uploads-pt", "efsVolumeConfiguration": { "fileSystemId": "fs-REPLACE_ME", "rootDirectory": "/pt-uploads", ... } },
  { "name": "uploads-es", "efsVolumeConfiguration": { "fileSystemId": "fs-REPLACE_ME", "rootDirectory": "/es-uploads", ... } }
]
```

Escolha de usar **2 volumes num mesmo EFS** (via `rootDirectory` diferente) em vez de 2 EFS distintos: reduz custo fixo de mount targets e simplifica backup.

## :warning: Pré-requisitos antes de merge/deploy

Este PR é **intencionalmente incompleto** — precisa dos passos abaixo na AWS antes do apply:

1. **Criar EFS** (mesma VPC/subnets do cluster ECS):
   ```bash
   aws efs create-file-system \
     --performance-mode generalPurpose \
     --throughput-mode bursting \
     --encrypted \
     --tags Key=Name,Value=deploy-adventistas-uploads
   ```

2. **Substituir `fs-REPLACE_ME`** (2 ocorrências) pelo `FileSystemId` criado. Ambos apontam ao mesmo EFS com `rootDirectory` diferente.

3. **Mount targets** em cada subnet onde o service ECS roda:
   ```bash
   aws efs create-mount-target --file-system-id fs-xxx --subnet-id subnet-yyy --security-groups sg-zzz
   ```

4. **Security Group do EFS** com inbound TCP 2049 (NFS) permitindo o SG das tasks ECS.

5. **Bootstrap** — copiar uploads atuais do container para o EFS antes do primeiro deploy, para não perder mídia existente:
   ```bash
   # Rodar uma task efêmera com o EFS montado
   aws ecs run-task --task-definition deploy-adventistas-bootstrap \
     --overrides '{"containerOverrides":[{"name":"ECSTASK","command":["bash","-c","cp -a /var/www/html/pt/wp-content/uploads/. /mnt/pt-uploads/ && cp -a /var/www/html/es/wp-content/uploads/. /mnt/es-uploads/"]}]}'
   ```

6. Deploy da nova task-definition → validar que uploads persistem entre redeploys.

## Alternativa descartada

**S3 via WP Offload Media** já está parcialmente configurado (`AS3CF_SETTINGS` em `wp-config.php`), mas não cobre cache do Elementor nem outros plugins que escrevem local. EFS é pré-requisito; S3 offload é otimização complementar para media library.

## Relacionado

- #2 (`fix/elementor-uploads-permissions`) — corrige permissões; esse PR completa a solução persistindo o cache.