### PR TITLE
fix: rewrite loop em .htaccess do multisite (AH00124 500)

### DIFF
--- a/app/es/.htaccess
+++ b/app/es/.htaccess
@@ -6,6 +6,6 @@ RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^ - [L]
-RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
-RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [END]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [END]
 RewriteRule . index.php [L]

--- a/app/pt/.htaccess
+++ b/app/pt/.htaccess
@@ -6,6 +6,6 @@ RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^ - [L]
-RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
-RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [END]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [END]
 RewriteRule . index.php [L]


### PR DESCRIPTION
## Root cause (confirmado nos logs)

Evidência do CloudWatch:

```
[Tue Apr 14 15:15:11 2026] [core:error] [pid 954:tid 954] [client 172.30.0.240:55260]
AH00124: Request exceeded the limit of 10 internal redirects due to probable
configuration error. Use 'LimitInternalRecursion' to increase the limit if necessary.
```

13+ entradas afetando múltiplos subsites (`mordomiacrista`, `familia`,
`liberdadereligiosa`, `remedios-naturais`). Não é permissão, nem cache, nem
Elementor — é **rewrite loop** no `.htaccess`.

## Por que o loop acontece

A regra do multisite em `/pt/.htaccess` e `/es/.htaccess`:

```apache
RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
```

O flag `[L]` em `.htaccess` per-directory do Apache 2.4 **apenas interrompe
o arquivo atual**. Após a reescrita, Apache faz internal redirect e reprocessa.

**Simulação** para `/pt/mordomiacrista/wp-content/uploads/sites/16/elementor/google-fonts/css/bebasneue.css`:

| Iteração | URL processada | Match | Reescreve para |
|----------|----------------|-------|----------------|
| 1 | `mordomiacrista/wp-content/uploads/.../bebasneue.css` | `$1='mordomiacrista/'`, `$2='wp-content/uploads/.../bebasneue.css'` | `wp-content/uploads/.../bebasneue.css` |
| 2 | `wp-content/uploads/.../bebasneue.css` | `$1=''`, `$2='wp-content/uploads/.../bebasneue.css'` | **mesma URL** |
| 3..10 | idem | idem | idem |
| 11 | — | — | Apache aborta → **500** |

O grupo opcional `([_0-9a-zA-Z-]+/)?` permite `$1` vazio → regra casa com a URL já reescrita → loop.

## Fix

Trocar `[L]` por `[END]` nas regras de reescrita:

```diff
-RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
-RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [END]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [END]
 RewriteRule . index.php [L]
```

- `[END]` (Apache 2.3.9+) impede novas entradas no rewrite engine mesmo após internal redirect
- Container usa Apache 2.4.65/66 → suporta `[END]`
- Mantido `[L]` na última regra (`index.php`) — é arquivo real, o `RewriteCond -f` já bloqueia reprocessamento natural

Aplicado em `/pt/` e `/es/`.

## Relação com PRs anteriores

- **#2** (permissões) — correto por si, mas não era a causa raiz do 500. Mantém como hardening para Elementor/CF7 escreverem em `uploads/`.
- **#3** (EFS) — independente deste fix, segue válido para persistência. Este fix resolve o erro sem EFS.

## Teste pós-deploy

```bash
curl -sI 'https://www.adventistas.org/pt/mordomiacrista/wp-content/uploads/sites/16/elementor/google-fonts/css/bebasneue.css?cb='$(date +%s)
# Esperado: HTTP/1.1 200 OK, Content-Type: text/css
```

Deve retornar o CSS real (Elementor gera no primeiro acesso com as permissões do PR #2).