### PR TITLE
fix: força Elementor a carregar Google Fonts via CDN (mu-plugin)

### DIFF
--- a/app/es/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
+++ b/app/es/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: Disable Elementor Local Google Fonts
+ * Description: Força o Elementor a carregar Google Fonts do CDN do Google em vez de criar arquivos em wp-content/uploads/elementor/google-fonts/. Resolve erros de MIME/404/500 quando o filesystem do container não persiste os arquivos entre deploys (ex: ECS sem volume EFS).
+ *
+ * Contorna o bug conhecido elementor/elementor#34657 onde desativar "Load Google Fonts Locally"
+ * via painel não é respeitado — os handles elementor-gf-local-* continuam sendo enfileirados.
+ *
+ * Version: 1.0.0
+ * Author: DevOps
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_filter( 'pre_option_elementor_experiment-e_local_google_fonts', function () {
+    return 'inactive';
+}, 99 );
+
+add_filter( 'pre_option_elementor_local_google_fonts', function () {
+    return '';
+}, 99 );
+
+add_filter( 'elementor/fonts/google/local_cache', '__return_false', 99 );
+add_filter( 'elementor/frontend/print_google_fonts', '__return_true', 99 );
+
+add_action( 'wp_enqueue_scripts', function () {
+    global $wp_styles;
+    if ( ! isset( $wp_styles ) || ! is_object( $wp_styles ) ) {
+        return;
+    }
+    foreach ( (array) $wp_styles->registered as $handle => $style ) {
+        if ( strpos( $handle, 'elementor-gf-local-' ) === 0 ) {
+            wp_dequeue_style( $handle );
+            wp_deregister_style( $handle );
+        }
+    }
+}, PHP_INT_MAX );

--- a/app/pt/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
+++ b/app/pt/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: Disable Elementor Local Google Fonts
+ * Description: Força o Elementor a carregar Google Fonts do CDN do Google em vez de criar arquivos em wp-content/uploads/elementor/google-fonts/. Resolve erros de MIME/404/500 quando o filesystem do container não persiste os arquivos entre deploys (ex: ECS sem volume EFS).
+ *
+ * Contorna o bug conhecido elementor/elementor#34657 onde desativar "Load Google Fonts Locally"
+ * via painel não é respeitado — os handles elementor-gf-local-* continuam sendo enfileirados.
+ *
+ * Version: 1.0.0
+ * Author: DevOps
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_filter( 'pre_option_elementor_experiment-e_local_google_fonts', function () {
+    return 'inactive';
+}, 99 );
+
+add_filter( 'pre_option_elementor_local_google_fonts', function () {
+    return '';
+}, 99 );
+
+add_filter( 'elementor/fonts/google/local_cache', '__return_false', 99 );
+add_filter( 'elementor/frontend/print_google_fonts', '__return_true', 99 );
+
+add_action( 'wp_enqueue_scripts', function () {
+    global $wp_styles;
+    if ( ! isset( $wp_styles ) || ! is_object( $wp_styles ) ) {
+        return;
+    }
+    foreach ( (array) $wp_styles->registered as $handle => $style ) {
+        if ( strpos( $handle, 'elementor-gf-local-' ) === 0 ) {
+            wp_dequeue_style( $handle );
+            wp_deregister_style( $handle );
+        }
+    }
+}, PHP_INT_MAX );


### PR DESCRIPTION
## Problema

Mesmo com os PRs #2 (permissões) e #4 (rewrite loop) deployed, o Elementor continua tentando carregar Google Fonts de arquivos locais que não existem:

```
Refused to apply style from 'https://www.adventistas.org/pt/.../elementor/google-fonts/css/lato.css'
because its MIME type ('text/html') is not a supported stylesheet MIME type
```

### Por que persiste

Existe bug conhecido [elementor/elementor#34657](https://github.com/elementor/elementor/issues/34657) (fev/2026): desativar **Elementor → Settings → Performance → Load Google Fonts Locally** via painel **não é respeitado**. Os handles `elementor-gf-local-*` continuam sendo enfileirados no frontend mesmo depois de:

- Alterar o toggle para Inactive
- Salvar
- Clear Files & Data
- Regenerate CSS

## Fix

Mu-plugin em `/pt/` e `/es/` com defesa em camadas:

1. **`pre_option` filters** — forçam options `elementor_local_google_fonts` e `elementor_experiment-e_local_google_fonts` a retornar valor desativado independente do que está no banco
2. **`elementor/fonts/google/local_cache` filter** — retorna `false` (impede tentativa de cache local em runtime)
3. **`elementor/frontend/print_google_fonts` filter** — retorna `true` (força `<link>` direto pro Google CDN)
4. **`wp_enqueue_scripts` em `PHP_INT_MAX`** — dequeue/deregister defensivo de qualquer handle `elementor-gf-local-*` que tenha escapado (contorna #34657)

## Por que mu-plugin (e não plugin normal)

- Carrega **antes** do Elementor inicializar
- Não pode ser desativado pelo painel (admin não vê em Plugins)
- Sobrevive a updates e novas instalações

## Cobertura

Só há 2 instalações WordPress no repo:
- `/pt/` (multisite — cobre site principal + mordomiacrista + 7class + liberdadereligiosa + familia + todos os outros subsites)
- `/es/` (multisite espanhol — mesma cobertura)

As demais pastas (`adra`, `biblia`, `adolescente`, `musica`, etc.) são redirects PHP ou conteúdo estático — não usam WordPress.

`mu-plugins` é compartilhado entre todos os subsites do multisite → aplica automaticamente em todos.

## Trade-off

Google Fonts passa a carregar via `fonts.googleapis.com` em vez de servidor próprio. Impacto:

- ➕ Elimina dependência de filesystem/EFS para CSS dinâmico
- ➕ Resolve os erros de MIME/404 sem precisar regenerar cache
- ➖ Dependência do Google CDN (que já tem >99.99% uptime)
- ➖ Leve perda de performance vs. same-origin (compensada por HTTP/2 multiplex + cache navegador)

Se quiserem voltar ao cache local no futuro (quando o bug #34657 for corrigido e o PR #3 EFS for aplicado), basta remover este mu-plugin.

## Teste pós-deploy

1. Aguardar deploy do workflow ECS (~12 min)
2. Abrir `https://www.adventistas.org/pt/7class/` em aba anônima
3. Verificar console → erros `Refused to apply style` devem sumir
4. Inspecionar HTML → `<link>` de Google Fonts deve apontar para `fonts.googleapis.com` (não mais para `/wp-content/uploads/elementor/google-fonts/`)

## PRs relacionados

- #2 — permissões (merged, deployed)
- #3 — EFS persistence (aberto, pré-requisito AWS)
- #4 — rewrite loop (merged, deployed)
- **#5 — este PR** (complementa #2/#4 removendo dependência de filesystem)