### PR TITLE
perf: remover NewRelic + chown/chmod em build-time

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -49,9 +49,7 @@ jobs:
           --build-arg WP_DB_USER='${{ secrets.WP_DB_USER }}' \
           --build-arg WP_S3_ACCESS_KEY='${{ secrets.AWS_ACCESS_KEY_ID }}' \
           --build-arg WP_S3_SECRET_KEY='${{ secrets.AWS_SECRET_ACCESS_KEY }}' \
-          --build-arg WP_S3_BUCKET='${{ secrets.WP_S3_BUCKET }}' \
-          --build-arg NEWRELIC_KEY='${{ secrets.NEWRELIC_KEY }}' \
-          --build-arg NEWRELIC_APP_NAME='${{ secrets.NEWRELIC_APP_NAME }}' .
+          --build-arg WP_S3_BUCKET='${{ secrets.WP_S3_BUCKET }}' .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         echo "Init transform: task-definition.json"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,21 @@ COPY --chown=www-data:www-data --from=internetdsa/pa-theme-sedes /var/www/build 
 COPY --chown=www-data:www-data --from=internetdsa/pa-theme-sedes-child /var/www/build /var/www/html/pt/wp-content/themes/pa-theme-sedes-child
 COPY --chown=www-data:www-data --from=internetdsa/pa-theme-sedes-child /var/www/build /var/www/html/es/wp-content/themes/pa-theme-sedes-child
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget gnupg ca-certificates \
+ && echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' > /etc/apt/sources.list.d/newrelic.list \
+ && wget -qO- https://download.newrelic.com/548C16BF.gpg | apt-key add - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends newrelic-php5 \
+ && NR_INSTALL_SILENT=1 newrelic-install install \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN chown -R www-data:www-data /var/www/html \
+ && find /var/www/html -type d -exec chmod 755 {} \; \
+ && find /var/www/html -type f -exec chmod 644 {} \; \
+ && find /var/www/html -type d -path '*/wp-content/uploads*' -exec chmod 775 {} \;
+
 COPY extras/init /usr/local/bin/docker-entrypoint.sh
 COPY extras/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY extras/php.ini $PHP_INI_DIR/conf.d/php.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,6 @@ COPY --chown=www-data:www-data --from=internetdsa/pa-theme-sedes /var/www/build 
 COPY --chown=www-data:www-data --from=internetdsa/pa-theme-sedes-child /var/www/build /var/www/html/pt/wp-content/themes/pa-theme-sedes-child
 COPY --chown=www-data:www-data --from=internetdsa/pa-theme-sedes-child /var/www/build /var/www/html/es/wp-content/themes/pa-theme-sedes-child
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends wget gnupg ca-certificates \
- && echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' > /etc/apt/sources.list.d/newrelic.list \
- && wget -qO- https://download.newrelic.com/548C16BF.gpg | apt-key add - \
- && apt-get update \
- && apt-get install -y --no-install-recommends newrelic-php5 \
- && NR_INSTALL_SILENT=1 newrelic-install install \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
 RUN chown -R www-data:www-data /var/www/html \
  && find /var/www/html -type d -exec chmod 755 {} \; \
  && find /var/www/html -type f -exec chmod 644 {} \; \
@@ -35,8 +25,6 @@ ARG WP_DB_USER
 ARG WP_S3_ACCESS_KEY
 ARG WP_S3_SECRET_KEY
 ARG WP_S3_BUCKET
-ARG NEWRELIC_KEY
-ARG NEWRELIC_APP_NAME
 
 ENV WP_DB_HOST=$WP_DB_HOST
 ENV WP_DB_NAME=$WP_DB_NAME
@@ -45,8 +33,6 @@ ENV WP_DB_USER=$WP_DB_USER
 ENV WP_S3_ACCESS_KEY=$WP_S3_ACCESS_KEY
 ENV WP_S3_SECRET_KEY=$WP_S3_SECRET_KEY
 ENV WP_S3_BUCKET=$WP_S3_BUCKET
-ENV NEWRELIC_KEY=$NEWRELIC_KEY
-ENV NEWRELIC_APP_NAME=$NEWRELIC_APP_NAME
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/extras/init
+++ b/extras/init
@@ -1,32 +1,16 @@
 #!/bin/bash
 
-echo "Instala integração com o NewRelic"
-apt-get update
-apt-get -y install sudo wget gnupg
-echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
-wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
-sudo apt-get update
-sudo apt-get -y install newrelic-php5
-sudo NR_INSTALL_SILENT=1 newrelic-install install
-sed -i -e "s/REPLACE_WITH_REAL_KEY/$NEWRELIC_KEY/" \
-  -e "s/newrelic.appname[[:space:]]=[[:space:]].*/newrelic.appname=\"$NEWRELIC_APP_NAME\"/" \
-  -e '$anewrelic.distributed_tracing_enabled=true' \
-  -e '$anewrelic.framework.wordpress.hooks=true' \
-  -e '$anewrelic.loglevel=error' \
-  $(php -r "echo(PHP_CONFIG_FILE_SCAN_DIR);")/newrelic.ini
-echo "Fim da instalação do NewRelic"
+if [ -n "$NEWRELIC_KEY" ]; then
+  NR_INI="$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/newrelic.ini"
+  if [ -f "$NR_INI" ]; then
+    sed -i \
+      -e "s/REPLACE_WITH_REAL_KEY/$NEWRELIC_KEY/" \
+      -e "s/newrelic.appname[[:space:]]=[[:space:]].*/newrelic.appname=\"$NEWRELIC_APP_NAME\"/" \
+      -e '$anewrelic.distributed_tracing_enabled=true' \
+      -e '$anewrelic.framework.wordpress.hooks=true' \
+      -e '$anewrelic.loglevel=error' \
+      "$NR_INI"
+  fi
+fi
 
-echo "Ajuste nas permissões da pasta uploads"
-rm -rf /var/www/html/wp-content
-chown -R www-data:www-data /var/www/html
-find /var/www/html -type d -exec chmod 755 {} \;
-find /var/www/html -type f -exec chmod 644 {} \;
-# wp-content/uploads precisa ser writable pelo PHP (Elementor gera Google Fonts CSS em runtime,
-# Contact Form 7 gera captchas/uploads, iThemes Security grava logs). Sem 775, o processo
-# PHP (www-data) não consegue criar sites/{N}/elementor/google-fonts/css/*.css e o WordPress
-# serve 404 HTML — navegador rejeita por MIME mismatch ('text/html' não é stylesheet).
-find /var/www/html -type d -path '*/wp-content/uploads*' -exec chmod 775 {} \;
-chmod 755 /var/www/html
-
-echo "Fim do script"
 exec "$@"

--- a/extras/init
+++ b/extras/init
@@ -1,16 +1,3 @@
 #!/bin/bash
 
-if [ -n "$NEWRELIC_KEY" ]; then
-  NR_INI="$(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/newrelic.ini"
-  if [ -f "$NR_INI" ]; then
-    sed -i \
-      -e "s/REPLACE_WITH_REAL_KEY/$NEWRELIC_KEY/" \
-      -e "s/newrelic.appname[[:space:]]=[[:space:]].*/newrelic.appname=\"$NEWRELIC_APP_NAME\"/" \
-      -e '$anewrelic.distributed_tracing_enabled=true' \
-      -e '$anewrelic.framework.wordpress.hooks=true' \
-      -e '$anewrelic.loglevel=error' \
-      "$NR_INI"
-  fi
-fi
-
 exec "$@"


### PR DESCRIPTION
## Contexto

Deploys atuais levam 20-25min (baseline esperado: 11-12min). O entrypoint `extras/init` faz trabalho caro em runtime que poderia ser build-time ou simplesmente eliminado.

## Mudanças

### 1. Remoção completa do NewRelic

- Dockerfile: remove install do pacote `newrelic-php5` + `newrelic-install`
- Dockerfile: remove `ARG/ENV NEWRELIC_KEY` e `NEWRELIC_APP_NAME`
- `extras/init`: remove configuração do `newrelic.ini` via sed
- Workflow `aws.yml`: remove `--build-arg NEWRELIC_KEY` e `NEWRELIC_APP_NAME`

**Benefícios:**
- Imagem ~30-50MB menor (sem `newrelic-php5` + `.deb` + headers)
- Boot mais rápido (sem `apt-get install` em runtime nem sed do ini)
- Superfície de segurança reduzida (sem license key na imagem)
- Um serviço a menos para monitorar/pagar

**Trade-off:**
- Perda de APM do NewRelic. Se precisar no futuro, alternativas: CloudWatch Container Insights (já incluso no ECS), Datadog, AppDynamics, Grafana+Tempo+Prometheus self-hosted.

### 2. chown + chmod em build-time (otimização original mantida)

Movidos do entrypoint para o Dockerfile:
```dockerfile
RUN chown -R www-data:www-data /var/www/html \
 && find /var/www/html -type d -exec chmod 755 {} \; \
 && find /var/www/html -type f -exec chmod 644 {} \; \
 && find /var/www/html -type d -path '*/wp-content/uploads*' -exec chmod 775 {} \;
```

Em 49k arquivos esse `find chmod` levava ~20-60s a cada container novo. Agora roda 1x no build e fica na imagem.

## Entrypoint final

```bash
#!/bin/bash
exec "$@"
```

Mínimo absoluto — só passa controle para o comando do Apache.

## Ganho estimado

- Boot de container: **~60-90s → <3s**
- Deploy end-to-end: **~20-25min → ~12-15min** (assumindo capacidade ECS suficiente)
- Imagem: **~30-50MB menor**

## Cleanup opcional após merge

Os secrets `NEWRELIC_KEY` e `NEWRELIC_APP_NAME` podem ser removidos do repository settings → Secrets (GitHub). Não causam problema se ficarem, mas ficam órfãos.

## O que NÃO resolve

Problema de capacidade do cluster ECS EC2 (tasks aguardando slot durante rolling deployment). Para isso:
- Aumentar ASG do cluster
- Ou ajustar `deploymentConfiguration.minimumHealthyPercent: 50` no service (requer `aws ecs update-service`)

Este PR é ortogonal — reduz o tempo de trabalho do ECS, mas não aumenta capacidade.

## PRs relacionados

- #2/#4/#5 — fixes funcionais do Elementor/Apache
- #3 — EFS persistence (independente)