### PR TITLE
fix: mu-plugin v1.1 — compatível com Elementor 4.0.1

### DIFF
--- a/app/es/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
+++ b/app/es/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
@@ -3,10 +3,19 @@
  * Plugin Name: Disable Elementor Local Google Fonts
  * Description: Força o Elementor a carregar Google Fonts do CDN do Google em vez de criar arquivos em wp-content/uploads/elementor/google-fonts/. Resolve erros de MIME/404/500 quando o filesystem do container não persiste os arquivos entre deploys (ex: ECS sem volume EFS).
  *
- * Contorna o bug conhecido elementor/elementor#34657 onde desativar "Load Google Fonts Locally"
- * via painel não é respeitado — os handles elementor-gf-local-* continuam sendo enfileirados.
+ * Baseado no fluxo do Elementor 4.0.1 em
+ * plugins/elementor/core/files/fonts/google-font.php::enqueue():
  *
- * Version: 1.0.0
+ *   if ( static::enqueue_style( $font_name ) ) return true;   // usa local se já tem dados
+ *   $is_local_gf_enabled = (bool) get_option( 'elementor_local_google_fonts', '0' );
+ *   if ( ! $is_local_gf_enabled ) $force_enqueue_from_cdn = true;
+ *   if ( $force_enqueue_from_cdn || ! fetch_font_data(...) ) enqueue_from_cdn(...);
+ *
+ * O branch `enqueue_style` lê a option `_elementor_local_google_fonts` (com underscore
+ * prefix — é onde ficam os DADOS das fontes já baixadas). Se já tem dados, Elementor
+ * nunca chega na flag — por isso filtramos AMBAS as options.
+ *
+ * Version: 1.1.0
  * Author: DevOps
  */
 
@@ -14,16 +23,17 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-add_filter( 'pre_option_elementor_experiment-e_local_google_fonts', function () {
-    return 'inactive';
+add_filter( 'pre_option__elementor_local_google_fonts', function () {
+    return [];
 }, 99 );
 
 add_filter( 'pre_option_elementor_local_google_fonts', function () {
-    return '';
+    return '0';
 }, 99 );
 
-add_filter( 'elementor/fonts/google/local_cache', '__return_false', 99 );
-add_filter( 'elementor/frontend/print_google_fonts', '__return_true', 99 );
+add_filter( 'pre_option_elementor_experiment-e_local_google_fonts', function () {
+    return 'inactive';
+}, 99 );
 
 add_action( 'wp_enqueue_scripts', function () {
     global $wp_styles;
@@ -37,3 +47,14 @@ add_action( 'wp_enqueue_scripts', function () {
         }
     }
 }, PHP_INT_MAX );
+
+add_filter( 'style_loader_src', function ( $src, $handle ) {
+    if ( false === $src || empty( $src ) ) {
+        return $src;
+    }
+    if ( strpos( $src, '/wp-content/uploads/' ) !== false
+        && strpos( $src, '/elementor/google-fonts/' ) !== false ) {
+        return false;
+    }
+    return $src;
+}, PHP_INT_MAX, 2 );

--- a/app/pt/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
+++ b/app/pt/wp-content/mu-plugins/disable-elementor-local-google-fonts.php
@@ -3,10 +3,19 @@
  * Plugin Name: Disable Elementor Local Google Fonts
  * Description: Força o Elementor a carregar Google Fonts do CDN do Google em vez de criar arquivos em wp-content/uploads/elementor/google-fonts/. Resolve erros de MIME/404/500 quando o filesystem do container não persiste os arquivos entre deploys (ex: ECS sem volume EFS).
  *
- * Contorna o bug conhecido elementor/elementor#34657 onde desativar "Load Google Fonts Locally"
- * via painel não é respeitado — os handles elementor-gf-local-* continuam sendo enfileirados.
+ * Baseado no fluxo do Elementor 4.0.1 em
+ * plugins/elementor/core/files/fonts/google-font.php::enqueue():
  *
- * Version: 1.0.0
+ *   if ( static::enqueue_style( $font_name ) ) return true;   // usa local se já tem dados
+ *   $is_local_gf_enabled = (bool) get_option( 'elementor_local_google_fonts', '0' );
+ *   if ( ! $is_local_gf_enabled ) $force_enqueue_from_cdn = true;
+ *   if ( $force_enqueue_from_cdn || ! fetch_font_data(...) ) enqueue_from_cdn(...);
+ *
+ * O branch `enqueue_style` lê a option `_elementor_local_google_fonts` (com underscore
+ * prefix — é onde ficam os DADOS das fontes já baixadas). Se já tem dados, Elementor
+ * nunca chega na flag — por isso filtramos AMBAS as options.
+ *
+ * Version: 1.1.0
  * Author: DevOps
  */
 
@@ -14,16 +23,17 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-add_filter( 'pre_option_elementor_experiment-e_local_google_fonts', function () {
-    return 'inactive';
+add_filter( 'pre_option__elementor_local_google_fonts', function () {
+    return [];
 }, 99 );
 
 add_filter( 'pre_option_elementor_local_google_fonts', function () {
-    return '';
+    return '0';
 }, 99 );
 
-add_filter( 'elementor/fonts/google/local_cache', '__return_false', 99 );
-add_filter( 'elementor/frontend/print_google_fonts', '__return_true', 99 );
+add_filter( 'pre_option_elementor_experiment-e_local_google_fonts', function () {
+    return 'inactive';
+}, 99 );
 
 add_action( 'wp_enqueue_scripts', function () {
     global $wp_styles;
@@ -37,3 +47,14 @@ add_action( 'wp_enqueue_scripts', function () {
         }
     }
 }, PHP_INT_MAX );
+
+add_filter( 'style_loader_src', function ( $src, $handle ) {
+    if ( false === $src || empty( $src ) ) {
+        return $src;
+    }
+    if ( strpos( $src, '/wp-content/uploads/' ) !== false
+        && strpos( $src, '/elementor/google-fonts/' ) !== false ) {
+        return false;
+    }
+    return $src;
+}, PHP_INT_MAX, 2 );


### PR DESCRIPTION
## Contexto

O PR #5 foi mergeado com o mu-plugin v1.0 que **não funcionava** — pelos testes em produção, os erros `Refused to apply style (MIME text/html)` continuavam aparecendo no console mesmo após deploy + Clear Files & Data.

Investigação: inspecionei o código do Elementor 4.0.1 (versão em uso) em `plugins/elementor/core/files/fonts/google-font.php`:

```php
public static function enqueue( string $font_name, ... ): bool {
    if ( static::enqueue_style( $font_name ) ) {              // caminho 1
        return true;
    }
    $is_local_gf_enabled = (bool) get_option( 'elementor_local_google_fonts', '0' );
    if ( ! $is_local_gf_enabled ) $force_enqueue_from_cdn = true;
    if ( $force_enqueue_from_cdn || ! fetch_font_data(...) ) enqueue_from_cdn(...);
    return static::enqueue_style( $font_name );
}
```

O **caminho 1** (`enqueue_style`) consulta a option `_elementor_local_google_fonts` (com **underscore prefix** — dados das fontes já baixadas). **Se tem dados, Elementor nunca chega no caminho 2** (que lê a flag).

v1.0 atacava só a flag `elementor_local_google_fonts` (sem underscore) — inútil quando já há dados.

## Fix v1.1

**Filtrar ambas options:**

```php
add_filter( 'pre_option__elementor_local_google_fonts', fn() => [], 99 );   // ← UNDERSCORE (dados)
add_filter( 'pre_option_elementor_local_google_fonts',  fn() => '0', 99 );  // ← sem underscore (flag)
```

Com `[]` nos dados: `get_font_data()` retorna `null` → `enqueue_style()` retorna `false` → cai no caminho 2 → lê a flag como `'0'` → `$force_enqueue_from_cdn = true` → `enqueue_from_cdn()` é chamado. ✅

**Removidos (não existem no Elementor 4.0.1):**
- `elementor/fonts/google/local_cache`
- `elementor/frontend/print_google_fonts`

**Adicionado (defesa em profundidade):**
```php
add_filter( 'style_loader_src', function ( $src, $handle ) {
    if ( strpos( $src, '/wp-content/uploads/' ) !== false
        && strpos( $src, '/elementor/google-fonts/' ) !== false ) {
        return false;
    }
    return $src;
}, PHP_INT_MAX, 2 );
```

Pega qualquer URL que tenha escapado dos filters de option.

## Teste pós-deploy

1. Aguardar workflow deploy completar
2. No admin Elementor → Ferramentas → **Clear Files & Data**
3. Abrir `https://www.adventistas.org/pt/7class/` em **aba anônima**
4. **Ctrl+U** (View Source) → procurar por `googleapis` — deve aparecer em `<link>` tags
5. Console → erros `Refused to apply style` devem sumir

## PRs relacionados

- #5 (v1.0 do mu-plugin) — merged mas sem efeito por bug no filter
- #6 — otimização de deploy (independente)